### PR TITLE
Change TransferSize header value

### DIFF
--- a/src/communication/bulk.rs
+++ b/src/communication/bulk.rs
@@ -103,7 +103,7 @@ pub fn read(
     };
     let request_header = request_device_dependent_msg_in_header(
         btag.get(),
-        bulk_in_endpoint.max_packet_size as u32,
+        misc::APPLICATION_BUFFER_SIZE,
         term_char,
     )?;
 
@@ -111,7 +111,7 @@ pub fn read(
     let mut output_data: Vec<u8> = Vec::new();
 
     let mut buffer: Vec<u8> =
-        vec![0x00; bulk_in_endpoint.max_packet_size as usize + misc::USBTMC_HEADER_SIZE];
+        vec![0x00; misc::APPLICATION_BUFFER_SIZE as usize + misc::USBTMC_HEADER_SIZE];
 
     // READING LOOP
     // ==========

--- a/src/init.rs
+++ b/src/init.rs
@@ -75,7 +75,7 @@ impl DeviceFilter for (u16, u16) {
         _device: &Device<T>,
         device_desc: &DeviceDescriptor,
     ) -> bool {
-        self.0 == device_desc.vendor_id() && self.0 == device_desc.product_id()
+        self.0 == device_desc.vendor_id() && self.1 == device_desc.product_id()
     }
 }
 


### PR DESCRIPTION
- Fixes a typo in the tuple device filter implementation.
- Changes the TransferSize of header value, see #5
 
Closes #5 